### PR TITLE
Added commands specific to BBD30x servo controllers

### DIFF
--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -2185,15 +2185,42 @@ def pol_req_params(dest: int, source: int):
     return _pack(0x0531, dest, source)
 
 
-def mot_set_mottrigioconfig(dest: int, source: int, chan_ident: int, trig_in_mode: int, trig_in_polarity: int,
-                            trig_in_source: int, trig_out_mode: int, trig_out_polarity: int, start_pos_fwd: int,
-                            interval_fwd: int, num_pulses_fwd: int, start_pos_rev: int, interval_rev: int,
-                            num_pulses_rev: int, pulse_width: int, num_cycles: int) -> bytes:
-    data = struct.pack("<6H8lH",
-                       chan_ident, trig_in_mode, trig_in_polarity, trig_in_source,
-                       trig_out_mode, trig_out_polarity, start_pos_fwd, interval_fwd,
-                       num_pulses_fwd, start_pos_rev, interval_rev,
-                       num_pulses_rev, pulse_width, num_cycles, 0)
+def mot_set_mottrigioconfig(
+    dest: int,
+    source: int,
+    chan_ident: int,
+    trig_in_mode: int,
+    trig_in_polarity: int,
+    trig_in_source: int,
+    trig_out_mode: int,
+    trig_out_polarity: int,
+    start_pos_fwd: int,
+    interval_fwd: int,
+    num_pulses_fwd: int,
+    start_pos_rev: int,
+    interval_rev: int,
+    num_pulses_rev: int,
+    pulse_width: int,
+    num_cycles: int,
+) -> bytes:
+    data = struct.pack(
+        "<6H8lH",
+        chan_ident,
+        trig_in_mode,
+        trig_in_polarity,
+        trig_in_source,
+        trig_out_mode,
+        trig_out_polarity,
+        start_pos_fwd,
+        interval_fwd,
+        num_pulses_fwd,
+        start_pos_rev,
+        interval_rev,
+        num_pulses_rev,
+        pulse_width,
+        num_cycles,
+        0,
+    )
     return _pack(0x0260, dest, source, data=data)
 
 
@@ -2201,7 +2228,9 @@ def mot_req_mottrigioconfig(dest: int, source: int, chan_ident: int) -> bytes:
     return _pack(0x0261, dest, source, param1=chan_ident)
 
 
-def mot_set_ioconfig(dest: int, source: int, io_port: int, mode: int, out_source: int) -> bytes:
+def mot_set_ioconfig(
+    dest: int, source: int, io_port: int, mode: int, out_source: int
+) -> bytes:
     data = struct.pack("<HHH", io_port, mode, out_source)
     return _pack(0x0263, dest, source, data=data)
 
@@ -2210,26 +2239,41 @@ def mot_req_ioconfig(dest: int, source: int, chan_ident: int, io_port: int) -> b
     return _pack(0x0264, dest, source, param1=chan_ident, param2=io_port)
 
 
-def mot_set_auxioconfig(dest: int, source: int, out_port: int, mode: int, sw_source: int) -> bytes:
+def mot_set_auxioconfig(
+    dest: int, source: int, out_port: int, mode: int, sw_source: int
+) -> bytes:
     data = struct.pack("<HHH", out_port, mode, sw_source)
     return _pack(0x0266, dest, source, data=data)
 
 
-def mot_req_auxioconfig(dest: int, source: int, chan_ident: int, out_port: int) -> bytes:
+def mot_req_auxioconfig(
+    dest: int, source: int, chan_ident: int, out_port: int
+) -> bytes:
     return _pack(0x0267, dest, source, param1=chan_ident, param2=out_port)
 
 
-def mot_set_analogmonitorconfig(dest: int, source: int, monitor: int, motor_channel: int, sys_var: int,
-                                scale: int, offset: int) -> bytes:
+def mot_set_analogmonitorconfig(
+    dest: int,
+    source: int,
+    monitor: int,
+    motor_channel: int,
+    sys_var: int,
+    scale: int,
+    offset: int,
+) -> bytes:
     data = struct.pack("<HHHll", monitor, motor_channel, sys_var, scale, offset)
     return _pack(0x0269, dest, source, data=data)
 
 
-def mot_req_analogmonitorconfig(dest: int, source: int, chan_ident: int, io_port: int) -> bytes:
-    return _pack(0x0270, dest, source, param1=chan_ident, param2 = io_port)
+def mot_req_analogmonitorconfig(
+    dest: int, source: int, chan_ident: int, io_port: int
+) -> bytes:
+    return _pack(0x0270, dest, source, param1=chan_ident, param2=io_port)
 
 
-def mot_set_postrigenstate(dest: int, source: int, chan_ident: int, state: int) -> bytes:
+def mot_set_postrigenstate(
+    dest: int, source: int, chan_ident: int, state: int
+) -> bytes:
     return _pack(0x0272, dest, source, param1=chan_ident, param2=state)
 
 
@@ -2237,9 +2281,17 @@ def mot_req_postrigenstate(dest: int, source: int, chan_ident: int) -> bytes:
     return _pack(0x0273, dest, source, param1=chan_ident)
 
 
-def mot_set_lcddisplayparams(dest: int, source: int, js_sensitivity: int, disp_brightness: int, disp_time_out: int,
-                             disp_dim_level: int) -> bytes:
-    data = struct.pack("<HHHHH", js_sensitivity, disp_brightness, disp_time_out, disp_dim_level, 0)
+def mot_set_lcddisplayparams(
+    dest: int,
+    source: int,
+    js_sensitivity: int,
+    disp_brightness: int,
+    disp_time_out: int,
+    disp_dim_level: int,
+) -> bytes:
+    data = struct.pack(
+        "<HHHHH", js_sensitivity, disp_brightness, disp_time_out, disp_dim_level, 0
+    )
     return _pack(0x0543, dest, source, data=data)
 
 
@@ -2247,9 +2299,28 @@ def mot_req_lcddisplayparams(dest: int, source: int, chan_ident: int) -> bytes:
     return _pack(0x0544, dest, source, param1=chan_ident)
 
 
-def mot_set_lcdmoveparams(dest: int, source: int, chan_ident: int, js_mode: int, jog_step_size: int,
-                          accn: int, max_vel: int, jog_stop_mode: int, preset_pos: int) -> bytes:
-    data = struct.pack("<HH3lHlH", chan_ident, js_mode, jog_step_size, accn, max_vel, jog_stop_mode, preset_pos, 0)
+def mot_set_lcdmoveparams(
+    dest: int,
+    source: int,
+    chan_ident: int,
+    js_mode: int,
+    jog_step_size: int,
+    accn: int,
+    max_vel: int,
+    jog_stop_mode: int,
+    preset_pos: int,
+) -> bytes:
+    data = struct.pack(
+        "<HH3lHlH",
+        chan_ident,
+        js_mode,
+        jog_step_size,
+        accn,
+        max_vel,
+        jog_stop_mode,
+        preset_pos,
+        0,
+    )
     return _pack(0x0546, dest, source, data=data)
 
 
@@ -2257,18 +2328,53 @@ def mot_req_lcdmoveparams(dest: int, source: int, chan_ident: int) -> bytes:
     return _pack(0x0547, dest, source, param1=chan_ident)
 
 
-def mot_set_movesyncharray(dest: int, source: int, array_id: int, channels: int, num_points: int, start_ix: int,
-                           time_pos: list[int]) -> bytes:
-    data = struct.pack("<HHHH" + "l" * len(time_pos), array_id, channels, num_points, start_ix, *time_pos)
+def mot_set_movesyncharray(
+    dest: int,
+    source: int,
+    array_id: int,
+    channels: int,
+    num_points: int,
+    start_ix: int,
+    time_pos: list[int],
+) -> bytes:
+    data = struct.pack(
+        "<HHHH" + "l" * len(time_pos),
+        array_id,
+        channels,
+        num_points,
+        start_ix,
+        *time_pos
+    )
     return _pack(0x0A00, dest, source, data=data)
 
 
-def mot_set_movesynchparams(dest: int, source: int, array_id: int, cycle_start_ix: int, cycle_end_ix: int,
-                            num_cycles: int, end_ix: int, deceleration: int) -> bytes:
-    data = struct.pack("<5Hl3H", array_id, cycle_start_ix, cycle_end_ix, num_cycles, end_ix, deceleration, 0, 0, 0)
+def mot_set_movesynchparams(
+    dest: int,
+    source: int,
+    array_id: int,
+    cycle_start_ix: int,
+    cycle_end_ix: int,
+    num_cycles: int,
+    end_ix: int,
+    deceleration: int,
+) -> bytes:
+    data = struct.pack(
+        "<5Hl3H",
+        array_id,
+        cycle_start_ix,
+        cycle_end_ix,
+        num_cycles,
+        end_ix,
+        deceleration,
+        0,
+        0,
+        0,
+    )
     return _pack(0x0A03, dest, source, data=data)
 
 
-def mot_move_synchstart(dest: int, source: int, array_id: int, channels: int, trigger: int) -> bytes:
+def mot_move_synchstart(
+    dest: int, source: int, array_id: int, channels: int, trigger: int
+) -> bytes:
     data = struct.pack("<3H", array_id, channels, trigger)
     return _pack(0x0A06, dest, source, data=data)

--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -1,5 +1,6 @@
 from typing import Optional, Sequence
 import struct
+from __future__ import annotations
 
 
 def _pack(

--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -9,7 +9,7 @@ def _pack(
     *,
     param1: int = 0,
     param2: int = 0,
-    data: Optional[bytes] = None
+    data: Optional[bytes] = None,
 ):
     if data is not None:
         assert param1 == param2 == 0
@@ -2338,12 +2338,7 @@ def mot_set_movesyncharray(
     time_pos: list[int],
 ) -> bytes:
     data = struct.pack(
-        f"<HHHH{len(time_pos)}l",
-        array_id,
-        channels,
-        num_points,
-        start_ix,
-        *time_pos
+        f"<HHHH{len(time_pos)}l", array_id, channels, num_points, start_ix, *time_pos
     )
     return _pack(0x0A00, dest, source, data=data)
 

--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -2338,7 +2338,7 @@ def mot_set_movesyncharray(
     time_pos: list[int],
 ) -> bytes:
     data = struct.pack(
-        "<HHHH" + "l" * len(time_pos),
+        f"<HHHH{len(time_pos)}l",
         array_id,
         channels,
         num_points,

--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -2183,3 +2183,92 @@ def pol_set_params(
 
 def pol_req_params(dest: int, source: int):
     return _pack(0x0531, dest, source)
+
+
+def mot_set_mottrigioconfig(dest: int, source: int, chan_ident: int, trig_in_mode: int, trig_in_polarity: int,
+                            trig_in_source: int, trig_out_mode: int, trig_out_polarity: int, start_pos_fwd: int,
+                            interval_fwd: int, num_pulses_fwd: int, start_pos_rev: int, interval_rev: int,
+                            num_pulses_rev: int, pulse_width: int, num_cycles: int) -> bytes:
+    data = struct.pack("<6H8lH",
+                       chan_ident, trig_in_mode, trig_in_polarity, trig_in_source,
+                       trig_out_mode, trig_out_polarity, start_pos_fwd, interval_fwd,
+                       num_pulses_fwd, start_pos_rev, interval_rev,
+                       num_pulses_rev, pulse_width, num_cycles, 0)
+    return _pack(0x0260, dest, source, data=data)
+
+
+def mot_req_mottrigioconfig(dest: int, source: int, chan_ident: int) -> bytes:
+    return _pack(0x0261, dest, source, param1=chan_ident)
+
+
+def mot_set_ioconfig(dest: int, source: int, io_port: int, mode: int, out_source: int) -> bytes:
+    data = struct.pack("<HHH", io_port, mode, out_source)
+    return _pack(0x0263, dest, source, data=data)
+
+
+def mot_req_ioconfig(dest: int, source: int, chan_ident: int, io_port: int) -> bytes:
+    return _pack(0x0264, dest, source, param1=chan_ident, param2=io_port)
+
+
+def mot_set_auxioconfig(dest: int, source: int, out_port: int, mode: int, sw_source: int) -> bytes:
+    data = struct.pack("<HHH", out_port, mode, sw_source)
+    return _pack(0x0266, dest, source, data=data)
+
+
+def mot_req_auxioconfig(dest: int, source: int, chan_ident: int, out_port: int) -> bytes:
+    return _pack(0x0267, dest, source, param1=chan_ident, param2=out_port)
+
+
+def mot_set_analogmonitorconfig(dest: int, source: int, monitor: int, motor_channel: int, sys_var: int,
+                                scale: int, offset: int) -> bytes:
+    data = struct.pack("<HHHll", monitor, motor_channel, sys_var, scale, offset)
+    return _pack(0x0269, dest, source, data=data)
+
+
+def mot_req_analogmonitorconfig(dest: int, source: int, chan_ident: int, io_port: int) -> bytes:
+    return _pack(0x0270, dest, source, param1=chan_ident, param2 = io_port)
+
+
+def mot_set_postrigenstate(dest: int, source: int, chan_ident: int, state: int) -> bytes:
+    return _pack(0x0272, dest, source, param1=chan_ident, param2=state)
+
+
+def mot_req_postrigenstate(dest: int, source: int, chan_ident: int) -> bytes:
+    return _pack(0x0273, dest, source, param1=chan_ident)
+
+
+def mot_set_lcddisplayparams(dest: int, source: int, js_sensitivity: int, disp_brightness: int, disp_time_out: int,
+                             disp_dim_level: int) -> bytes:
+    data = struct.pack("<HHHHH", js_sensitivity, disp_brightness, disp_time_out, disp_dim_level, 0)
+    return _pack(0x0543, dest, source, data=data)
+
+
+def mot_req_lcddisplayparams(dest: int, source: int, chan_ident: int) -> bytes:
+    return _pack(0x0544, dest, source, param1=chan_ident)
+
+
+def mot_set_lcdmoveparams(dest: int, source: int, chan_ident: int, js_mode: int, jog_step_size: int,
+                          accn: int, max_vel: int, jog_stop_mode: int, preset_pos: int) -> bytes:
+    data = struct.pack("<HH3lHlH", chan_ident, js_mode, jog_step_size, accn, max_vel, jog_stop_mode, preset_pos, 0)
+    return _pack(0x0546, dest, source, data=data)
+
+
+def mot_req_lcdmoveparams(dest: int, source: int, chan_ident: int) -> bytes:
+    return _pack(0x0547, dest, source, param1=chan_ident)
+
+
+def mot_set_movesyncharray(dest: int, source: int, array_id: int, channels: int, num_points: int, start_ix: int,
+                           time_pos: list[int]) -> bytes:
+    data = struct.pack("<HHHH" + "l" * len(time_pos), array_id, channels, num_points, start_ix, *time_pos)
+    return _pack(0x0A00, dest, source, data=data)
+
+
+def mot_set_movesynchparams(dest: int, source: int, array_id: int, cycle_start_ix: int, cycle_end_ix: int,
+                            num_cycles: int, end_ix: int, deceleration: int) -> bytes:
+    data = struct.pack("<5Hl3H", array_id, cycle_start_ix, cycle_end_ix, num_cycles, end_ix, deceleration, 0, 0, 0)
+    return _pack(0x0A03, dest, source, data=data)
+
+
+def mot_move_synchstart(dest: int, source: int, array_id: int, channels: int, trigger: int) -> bytes:
+    data = struct.pack("<3H", array_id, channels, trigger)
+    return _pack(0x0A06, dest, source, data=data)

--- a/thorlabs_apt_protocol/parsing.py
+++ b/thorlabs_apt_protocol/parsing.py
@@ -2020,9 +2020,23 @@ def pol_get_params(data: bytes) -> Dict[str, Any]:
 
 @parser(0x0262)
 def mot_get_mottrigioconfig(data: bytes) -> Dict[str, Any]:
-    chan_ident, trig_in_mode, trig_in_polarity, trig_in_source, trig_out_mode, trig_out_polarity,\
-    start_pos_fwd, interval_fwd, num_pulses_fwd, start_pos_rev, interval_rev, num_pulses_rev, pulse_width,\
-    num_cycles, _ = struct.unpack_from("<6H8lH", data, HEADER_SIZE)
+    (
+        chan_ident,
+        trig_in_mode,
+        trig_in_polarity,
+        trig_in_source,
+        trig_out_mode,
+        trig_out_polarity,
+        start_pos_fwd,
+        interval_fwd,
+        num_pulses_fwd,
+        start_pos_rev,
+        interval_rev,
+        num_pulses_rev,
+        pulse_width,
+        num_cycles,
+        _,
+    ) = struct.unpack_from("<6H8lH", data, HEADER_SIZE)
     return {
         "chan_ident": chan_ident,
         "trig_in_mode": trig_in_mode,
@@ -2063,7 +2077,9 @@ def mot_get_auxioconfig(data: bytes) -> Dict[str, Any]:
 
 @parser(0x0271)
 def mot_get_analogmonitorconfig(data: bytes) -> Dict[str, Any]:
-    monitor, motor_channel, sys_var, scale, offset = struct.unpack_from("<HHHll", data, HEADER_SIZE)
+    monitor, motor_channel, sys_var, scale, offset = struct.unpack_from(
+        "<HHHll", data, HEADER_SIZE
+    )
     return {
         "monitor": monitor,
         "motor_channel": motor_channel,
@@ -2074,13 +2090,19 @@ def mot_get_analogmonitorconfig(data: bytes) -> Dict[str, Any]:
 
 
 @parser(0x0274)
-def mot_get_postrigenstate(data:bytes) -> Dict[str, Any]:
+def mot_get_postrigenstate(data: bytes) -> Dict[str, Any]:
     return {"chan_ident": data[2], "state": data[3]}
 
 
 @parser(0x0545)
 def mot_get_lcddisplayparams(data: bytes) -> Dict[str, Any]:
-    js_sensitivity, disp_brightness, disp_time_out, disp_dim_level, _ = struct.unpack_from("<HHHHH", data, HEADER_SIZE)
+    (
+        js_sensitivity,
+        disp_brightness,
+        disp_time_out,
+        disp_dim_level,
+        _,
+    ) = struct.unpack_from("<HHHHH", data, HEADER_SIZE)
     return {
         "js_sensitivity": js_sensitivity,
         "disp_brightness": disp_brightness,
@@ -2091,7 +2113,16 @@ def mot_get_lcddisplayparams(data: bytes) -> Dict[str, Any]:
 
 @parser(0x0548)
 def mot_get_lcdmoveparams(data: bytes) -> Dict[str, Any]:
-    chan_ident, js_mode, jog_step_size, accn, max_vel, jog_stop_mode, preset_pos, _ = struct.unpack_from("<HH3lHlH",data, HEADER_SIZE)
+    (
+        chan_ident,
+        js_mode,
+        jog_step_size,
+        accn,
+        max_vel,
+        jog_stop_mode,
+        preset_pos,
+        _,
+    ) = struct.unpack_from("<HH3lHlH", data, HEADER_SIZE)
     return {
         "chan_ident": chan_ident,
         "js_mode": js_mode,

--- a/thorlabs_apt_protocol/parsing.py
+++ b/thorlabs_apt_protocol/parsing.py
@@ -2016,3 +2016,88 @@ def pol_get_params(data: bytes) -> Dict[str, Any]:
         "jog_step2": jog_step2,
         "jog_step3": jog_step3,
     }
+
+
+@parser(0x0262)
+def mot_get_mottrigioconfig(data: bytes) -> Dict[str, Any]:
+    chan_ident, trig_in_mode, trig_in_polarity, trig_in_source, trig_out_mode, trig_out_polarity,\
+    start_pos_fwd, interval_fwd, num_pulses_fwd, start_pos_rev, interval_rev, num_pulses_rev, pulse_width,\
+    num_cycles, _ = struct.unpack_from("<6H8lH", data, HEADER_SIZE)
+    return {
+        "chan_ident": chan_ident,
+        "trig_in_mode": trig_in_mode,
+        "trig_in_polarity": trig_in_polarity,
+        "trig_in_source": trig_in_source,
+        "trig_out_mode": trig_out_mode,
+        "trig_out_polarity": trig_out_polarity,
+        "start_pos_fwd": start_pos_fwd,
+        "interval_fwd": interval_fwd,
+        "num_pulses_fwd": num_pulses_fwd,
+        "start_pos_rev": start_pos_rev,
+        "interval_rev": interval_rev,
+        "num_pulses_rev": num_pulses_rev,
+        "pulse_width": pulse_width,
+        "num_cycles": num_cycles,
+    }
+
+
+@parser(0x0265)
+def mot_get_ioconfig(data: bytes) -> Dict[str, Any]:
+    io_port, mode, out_source = struct.unpack_from("<HHH", data, HEADER_SIZE)
+    return {
+        "io_port": io_port,
+        "mode": mode,
+        "out_source": out_source,
+    }
+
+
+@parser(0x0268)
+def mot_get_auxioconfig(data: bytes) -> Dict[str, Any]:
+    out_port, mode, sw_source = struct.unpack_from("<HHH", data, HEADER_SIZE)
+    return {
+        "out_port": out_port,
+        "mode": mode,
+        "sw_source": sw_source,
+    }
+
+
+@parser(0x0271)
+def mot_get_analogmonitorconfig(data: bytes) -> Dict[str, Any]:
+    monitor, motor_channel, sys_var, scale, offset = struct.unpack_from("<HHHll", data, HEADER_SIZE)
+    return {
+        "monitor": monitor,
+        "motor_channel": motor_channel,
+        "sys_var": sys_var,
+        "scale": scale,
+        "offset": offset,
+    }
+
+
+@parser(0x0274)
+def mot_get_postrigenstate(data:bytes) -> Dict[str, Any]:
+    return {"chan_ident": data[2], "state": data[3]}
+
+
+@parser(0x0545)
+def mot_get_lcddisplayparams(data: bytes) -> Dict[str, Any]:
+    js_sensitivity, disp_brightness, disp_time_out, disp_dim_level, _ = struct.unpack_from("<HHHHH", data, HEADER_SIZE)
+    return {
+        "js_sensitivity": js_sensitivity,
+        "disp_brightness": disp_brightness,
+        "disp_time_out": disp_time_out,
+        "disp_dim_level": disp_dim_level,
+    }
+
+
+@parser(0x0548)
+def mot_get_lcdmoveparams(data: bytes) -> Dict[str, Any]:
+    chan_ident, js_mode, jog_step_size, accn, max_vel, jog_stop_mode, preset_pos, _ = struct.unpack_from("<HH3lHlH",data, HEADER_SIZE)
+    return {
+        "chan_ident": chan_ident,
+        "js_mode": js_mode,
+        "jog_step_size": jog_step_size,
+        "accn": accn,
+        "max_vel": max_vel,
+        "jog_stop_mode": jog_stop_mode,
+        "preset_pos": preset_pos,
+    }


### PR DESCRIPTION
The commands listed on page 22 of the Thorlabs APT prodocol pdf, "Messages Applicable to BBD301, BBD302 and BBD303 Only", are currently missing from this project.  I have implemented them and tested basic send/receive functionality with a Thorlabs BBD302.