### PR TITLE
KLD101

### DIFF
--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -1628,6 +1628,10 @@ def la_ack_statusupdate(dest: int, source: int):
     return _pack(0x0822, dest, source)
 
 
+def ld_req_statusupdate(dest: int, source: int):
+    return _pack(0x0825, dest, source)
+
+
 def ld_ack_statusupdate(dest: int, source: int):
     return _pack(0x0827, dest, source)
 

--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -1612,7 +1612,7 @@ def ld_req_maxcurrentdigpot(dest: int, source: int):
     return _pack(0x0818, dest, source)
 
 
-def ld_findtiaagain(dest: int, source: int):
+def ld_findtiagain(dest: int, source: int):
     return _pack(0x081A, dest, source)
 
 

--- a/thorlabs_apt_protocol/functions.py
+++ b/thorlabs_apt_protocol/functions.py
@@ -1567,7 +1567,7 @@ def la_req_mmi_params(dest: int, source: int):
 
 
 def la_set_klddigoutputs(dest: int, source: int, dig_outputs: int) -> bytes:
-    data = struct.pack("<HHH", 14, dig_outputs, 0)
+    data = struct.pack("<HHH", 17, dig_outputs, 0)
     return _pack(0x0800, dest, source, data=data)
 
 

--- a/thorlabs_apt_protocol/parsing.py
+++ b/thorlabs_apt_protocol/parsing.py
@@ -1455,9 +1455,6 @@ def la_get_params(data: bytes) -> Dict[str, Any]:
     elif submsgid == 5:
         (laser_source,) = struct.unpack_from("<H", data, HEADER_SIZE)
         ret.update({"laser_source": laser_source})
-    elif submsgid == 5:
-        (laser_source,) = struct.unpack_from("<H", data, HEADER_SIZE)
-        ret.update({"laser_source": laser_source})
     elif submsgid == 7:
         (statusbits,) = struct.unpack_from("<L", data, HEADER_SIZE)
         ret.update(_parse_la_status_bits(statusbits))

--- a/thorlabs_apt_protocol/parsing.py
+++ b/thorlabs_apt_protocol/parsing.py
@@ -1438,7 +1438,7 @@ def nt_get_tnaiosettings(data: bytes) -> Dict[str, Any]:
     }
 
 
-@parser(0x0800)
+@parser(0x0802)
 def la_get_params(data: bytes) -> Dict[str, Any]:
     (submsgid,) = struct.unpack_from("<H", data, HEADER_SIZE)
     ret = {"submsgid": submsgid}


### PR DESCRIPTION
I went through the apt protocol stuff looking verifying messages used by to KLD101. Issue #16.
| looks good | msgid | function | changes |
|---|---|---|---|
| [x] | 0x0223 | mod_identify | |
| [x] | 0x0002 | hw_disconnect | |
| [x] | 0x0011 | hw_start_updatemsgs | |
| [x] | 0x0012 | hw_stop_updatemsgs | |
| [x] | 0x0005 | hw_req_info | |
| [x] | 0x0006 | hw_get_info | |
| [x] | 0x0800 | la_set_params | | 
| [x] | ID=0x01 | la_set_power_setpoint | | 
| [x] | ID=0x05 | la_set_laser_control_source | |
| [x] | ID=0x0B | la_set_display_settings | |
| [x] | ID=0x0D | la_set_misc_params | |
| [x] | ID=0x0E | la_set_mmi_params | |
| [x] | ID=0x11 | la_set_klddigoutputs | **corrected 14 -> 17** | 
| [x] | 0x0801 | la_req_params | |
| [x] | ID=0x01 | la_req_power_setpoint | |
| [x] | ID=0x03 | la_req_laser_current_and_power | |
| [x] | ID=0x05 | la_req_laser_control_source | |
| [x] | ID=0x07 | la_req_lastatusbits | |
| [x] | ID=0x09 | la_req_max_limits (TLS001) | |
| [x] | ID=0x0A | la_req_max_current (TLD001) |  |
| [x] | ID=0x0B | la_req_display_settings | |
| [x] | ID=0x0D | la_req_misc_params (TLD001) | |
| [x] | ID=0x0E | la_req_mmi_params | |
| [x] | ID=0x11 | la_req_klddigoutputs | |
| [x] | 0x0802 | la_get_params | **corrected 0x0800 -> 0x0802** | 
| [x] | ID=0x01 | la_get_power_setpoint | |
| [x] | ID=0x03 | la_get_laser_current_and_power | |
| [x] | ID=0x05 | la_get_laser_control_source | **removed duplicate elif** | 
| [x] | ID=0x07 | la_get_lastatusbits | |
| [x] | ID=0x09 | la_get_max_limits (TLS001) | |
| [x] | ID=0x0A | la_get_max_current (TLD001) | |
| [x] | ID=0x0B | la_get_display_settings ||
| [x] | ID=0x0D | la_get_misc_params (TLD001) | |
| [x] | ID=0x0E | la_get_mmi_params | |
| [x] | ID=0x11 | la_get_klddigoutputs | |
| [x] | 0x0810 | la_set_eepromparams| |
| [x] | 0x0811 | la_enableoutput | |
| [x] | 0x0812 | la_disableoutput | |
| [x] | 0x0813 | ld_openloop| |
| [x] | 0x0814 | ld_closedloop| |
| [ ] | 0x0815 | ld_potrotating (unclear, and I don't plan to use anyways. Manual says set, but "message is sent automatically by the system...") | |
| [x] | 0x0816 | ld_maxcurrentadjust ||
| [x] | 0x0817 | ld_set_maxcurrentdigipot ||
| [x] | 0x0818 | ld_req_maxcurrentdigipot ||
| [x] | 0x0819 | ld_get_maxcurrentdigipot ||
| [x] | 0x081A | ld_findtiagain |corrected function name|
| [x] | 0x081B | ld_tiagainadjust |  |
| [x] | 0x0825 | ld_req_statusupdate | **added in this PR** | 
| [x] | 0x0826 | ld_get_statusupdate | |
| [x] | 0x0827 | ld_ack_statusupdate ||
| [x] | 0x0250 | hw_set_kcubemmilock | |
| [x] | 0x0686 | restorefactorysettings ||
