### PR TITLE
unpacker now warns by default

### DIFF
--- a/thorlabs_apt_protocol/unpacker.py
+++ b/thorlabs_apt_protocol/unpacker.py
@@ -27,7 +27,7 @@ class Unpacker:
     :param on_error: Action to take if invalid data is detected.
     """
 
-    def __init__(self, file_like=None, on_error="continue"):
+    def __init__(self, file_like=None, on_error="warn"):
         if file_like is None:
             self._file = io.BytesIO()
         else:


### PR DESCRIPTION
If you want me to change the order of the error handling check, just let me know. Related to #16 . 

https://github.com/yaq-project/thorlabs-apt-protocol/blob/1bea2ccb6869d2e2a59f47858e4e59735ed97367/thorlabs_apt_protocol/unpacker.py#L41-L52